### PR TITLE
CancellationToken support for synchronous Lock

### DIFF
--- a/AsyncLock/AsyncLock.cs
+++ b/AsyncLock/AsyncLock.cs
@@ -78,12 +78,12 @@ namespace NeoSmart.AsyncLock
                 return this;
             }
 
-            internal IDisposable ObtainLock()
+            internal IDisposable ObtainLock(CancellationToken cancellationToken)
             {
                 while (!TryEnter())
                 {
                     // We need to wait for someone to leave the lock before trying again.
-                    _parent._retry.Wait();
+                    _parent._retry.Wait(cancellationToken);
                 }
                 return this;
             }
@@ -202,13 +202,13 @@ namespace NeoSmart.AsyncLock
             return @lock.ObtainLockAsync(ct);
         }
 
-        public IDisposable Lock()
+        public IDisposable Lock(CancellationToken cancellationToken = default)
         {
             var @lock = new InnerLock(this, _asyncId.Value, ThreadId);
             // Increment the async stack counter to prevent a child task from getting
             // the lock at the same time as a child thread.
             _asyncId.Value = Interlocked.Increment(ref AsyncLock.AsyncStackCounter);
-            return @lock.ObtainLock();
+            return @lock.ObtainLock(cancellationToken);
         }
     }
 }

--- a/UnitTests/CancellationTests.cs
+++ b/UnitTests/CancellationTests.cs
@@ -28,5 +28,33 @@ namespace AsyncLockTests
             }).Wait();
 
         }
+        [TestMethod]
+        public void CancellingWaitSync()
+        {
+            var asyncLock = new AsyncLock();
+            var cts = new CancellationTokenSource(500);
+            Task.Run(async () =>
+            {
+                using (asyncLock.Lock(cts.Token))
+                {
+                    // hold the lock until our later attempt is called
+                    await Task.Delay(1000);
+                }
+            });
+            Assert.ThrowsException<OperationCanceledException>(() =>
+            {
+                using (asyncLock.Lock(cts.Token))
+                {
+                    Assert.Fail("should never reach here if cancellation works properly.");
+                }
+            });
+            // we should still be able to obtain a lock afterward to make sure resources were reobtained
+            var newCts= new CancellationTokenSource(1000);
+            using (asyncLock.Lock(newCts.Token))
+            {
+                // reaching this line means the test passed
+                // a OperationCanceledException will indicate test failure
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds a CancellationToken parameter to the synchronous `AsyncLock.Lock` method. Closes #9.