### PR TITLE
Don't marshal async continuations to the captured context

### DIFF
--- a/AsyncLock/AsyncLock.cs
+++ b/AsyncLock/AsyncLock.cs
@@ -361,7 +361,7 @@ namespace NeoSmart.AsyncLock
                         disposableLock.Dispose();
                     }
                     return true;
-                });
+                }, TaskScheduler.Default);
         }
 
         // Make sure InnerLock.LockAsync() does not use await, because an async function triggers a snapshot of
@@ -395,8 +395,8 @@ namespace NeoSmart.AsyncLock
                             }
 
                             return true;
-                        });
-                }).Unwrap();
+                        }, TaskScheduler.Default);
+                }, TaskScheduler.Default).Unwrap();
         }
 
         // Make sure InnerLock.LockAsync() does not use await, because an async function triggers a snapshot of
@@ -428,7 +428,7 @@ namespace NeoSmart.AsyncLock
                         disposableLock.Dispose();
                     }
                     return true;
-                });
+                }, TaskScheduler.Default);
         }
 
         // Make sure InnerLock.LockAsync() does not use await, because an async function triggers a snapshot of
@@ -462,8 +462,8 @@ namespace NeoSmart.AsyncLock
                             }
 
                             return true;
-                        });
-                }).Unwrap();
+                        }, TaskScheduler.Default);
+                }, TaskScheduler.Default).Unwrap();
         }
 
         public IDisposable Lock(CancellationToken cancellationToken = default)
@@ -533,7 +533,7 @@ namespace NeoSmart.AsyncLock
                         var result = state.Result;
                         *(bool*)addrLong = result is not null;
                         return result ?? NullDisposable;
-                    }, TaskContinuationOptions.OnlyOnRanToCompletion);
+                    }, default(CancellationToken), TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
                 }
             }
         }
@@ -558,7 +558,7 @@ namespace NeoSmart.AsyncLock
                         var result = state.Result;
                         *(bool*)addrLong = result is not null;
                         return result ?? NullDisposable;
-                    }, TaskContinuationOptions.OnlyOnRanToCompletion);
+                    }, default(CancellationToken), TaskContinuationOptions.OnlyOnRanToCompletion, TaskScheduler.Default);
                 }
             }
         }


### PR DESCRIPTION
Currently, `async`/`await` continuations and `Task.ContinueWith(...)` continuations are marshalled back to the captured context (`TaskScheduler` or `SynchronizationContext`) as is the default behavior with these tools. I believe there is no reason for this in this library. An example of this is if I use this library in an ASP.NET Core web project currently, this library will post its continuations to the web framework's single-threaded UI synchronization context, resulting in worse performance and even deadlocks if asynchronous code is blocked on.

This resolves the issue by 1) using `Task.ConfigureAwait(false)` in `async`/`await` code to instruct the async state machines to schedule continuations onto the default thread pool and 2) passing `TaskScheduler.Default` to `Task.ContinueWith(...)` calls to ensure the continuations are run on the default thread pool.

Notably, `Task.Run(...)` schedules work onto the default thread pool by default, so no changes are needed there. Only continuations are subject to this "marshalling onto the captured context" behavior by default.

Resolves #17.